### PR TITLE
Tables can display nested data structures

### DIFF
--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -1,6 +1,6 @@
 (ns wilson.dom
   "Tools for building DOMs."
-  (:require [wilson.utils :refer [capitalize]]
+  (:require [wilson.utils :refer [capitalize kw->dot-notation get-or-get-in]]
             [clojure.string :as string]))
 
 (defn table
@@ -10,12 +10,12 @@
     [:thead
      (into [:tr]
            (for [k keys]
-             [:th (capitalize k)]))]
+             [:th (-> k kw->dot-notation capitalize)]))]
     (into [:tbody]
           (for [row rows]
             (into [:tr (row->attrs row)]
                   (for [k keys]
-                    [:td (get row k)]))))])
+                    [:td (get-or-get-in row k)]))))])
   ([keys rows]
    (table keys rows {:row->attrs (constantly {})})))
 

--- a/src/wilson/utils.cljc
+++ b/src/wilson/utils.cljc
@@ -45,3 +45,19 @@
   [super sub]
   #?(:clj (.contains ^String super sub)
      :cljs (not= (.indexOf super sub) -1)))
+
+(defn get-or-get-in
+  "Will use get when keyword is passed or get-in for vectors"
+  [d kw]
+  (if (vector? kw)
+      (get-in d kw)
+      (get d kw)))
+
+(defn kw->dot-notation
+  "Turns a vector of keywords into a string with corresponding
+  dot-notation (e.g.: [:a :b :c] becomes \"a.b.c\".
+  Keywords are returned using `name` function."
+  [kw]
+  (if (vector? kw)
+      (string/join "." (map name kw))
+      (name kw)))

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -62,6 +62,39 @@
               [:td "x"]
               [:td "y"]
               [:td (d/label "warning" "z")]]]])))
+  (testing "table with nested data"
+    (is (= (d/table [:a-key :some-key [:a :b :c]]
+                    [{:a-key (d/label "warning" "h")
+                      :some-key "i"
+                      :hidden "hidden"
+                      :a {:b {:c 123}}}
+                     {:a-key "p"
+                      :some-key (d/label "warning" "q")
+                      :hidden "hidden"
+                      :a {:b {:c 456}}}
+                     {:a-key "x"
+                      :some-key "y"
+                      :hidden "hidden"
+                      :a {:b {:c "abc"}}}])
+           [:table {:class "table table-hover"}
+            [:thead
+             [:tr
+              [:th "A key"]
+              [:th "Some key"]
+              [:th "A.b.c"]]]
+            [:tbody
+             [:tr {}
+              [:td (d/label "warning" "h")]
+              [:td "i"]
+              [:td 123]]
+             [:tr {}
+              [:td "p"]
+              [:td (d/label "warning" "q")]
+              [:td 456]]
+             [:tr {}
+              [:td "x"]
+              [:td "y"]
+              [:td "abc"]]]])))
   (testing "table with per-row clases"
     (is (= (d/table [:a-key :some-key :some-other-key]
                     [{:a-key (d/label "warning" "h")

--- a/test/wilson/utils_test.cljc
+++ b/test/wilson/utils_test.cljc
@@ -66,3 +66,17 @@
   (are [super sub] (not (u/substr? super sub))
     "" "a"
     "abc" "def"))
+
+(deftest get-or-get-in-test
+  (let [data {:a 123
+              :b {:c "abc"}
+              :d :xyz}]
+    (are [in out] (= (u/get-or-get-in data in) out)
+    :a 123
+    [:b :c] "abc"
+    :d :xyz)))
+
+(deftest kw->dot-notation
+  (are [in out] (= (u/kw->dot-notation in) out)
+    [:a :b :c] "a.b.c"
+    :a (name :a)))


### PR DESCRIPTION
`dom.table` will be able to deal with nested data structures, e.g.:

```
{:a "abc"
 :b {:c 123}}
```
Headers on the table will be displayed using dot notation (e.g.: header for value `123` from example above would display as `B.c`)

