### PR TITLE
Better tables

### DIFF
--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -7,7 +7,7 @@
   [k]
   (if (keyword? k)
       (capitalize k)
-      (:descr (meta k))))
+      (::descr (meta k))))
 
 (defn prepare-keys
   [ks]
@@ -15,7 +15,7 @@
          (if (vector? k)
            (let [f #(get-in % k)
                  descr (capitalize (string/join "." (map name k)))]
-             (vary-meta f assoc :descr descr))
+             (vary-meta f assoc ::descr descr))
            k))
        ks))
 

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -6,7 +6,7 @@
 (defn describe-key
   [k]
   (if (keyword? k)
-      (name k)
+      (capitalize k)
       (:descr (meta k))))
 
 (defn prepare-keys
@@ -14,7 +14,7 @@
   (map (fn [k]
          (if (vector? k)
            (let [f #(get-in % k)
-                 descr (string/join "." (map name k))]
+                 descr (capitalize (string/join "." (map name k)))]
              (vary-meta f assoc :descr descr))
            k))
        ks))
@@ -30,7 +30,7 @@
       [:thead
        (into [:tr]
              (for [k ready-keys]
-               [:th (capitalize (describe-key k))]))]
+               [:th (describe-key k)]))]
       (into [:tbody]
             (for [row rows]
               (into [:tr (row->attrs row)]

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -11,6 +11,12 @@
 
 (defn prepare-keys
   [ks]
+  "Prepares keys for use with wilson.dom/table.
+  `ks` should be a collection of singular keys or vectors of keys
+  pointing at nested data. Vectors are converted into function
+  which (when run on data) will return the data they are poiting at.
+  They also come with a ::descr function in metadata, which describes the
+  path using dot notation (e.g.: [:a :b :c] will become 'A.b.c'."
   (map (fn [k]
          (if (vector? k)
            (let [f #(get-in % k)
@@ -20,7 +26,8 @@
        ks))
 
 (defn table
-  "Creates a table displaying the keys in the given rows of data."
+  "Creates a table displaying the keys in the given rows of data.
+  Accepts singular keys or vectors of keys pointing at nested data."
   ([ks rows {:keys [row->attrs describe-key prepare-keys]
                  :or {row->attrs (constantly {})
                       describe-key describe-key

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -5,6 +5,7 @@
 
 (defn describe-key
   [k]
+  "Returns a key in a human-readable form."
   (if (keyword? k)
       (capitalize k)
       (::descr (meta k))))
@@ -13,8 +14,7 @@
   [ks]
   "Prepares keys for use with wilson.dom/table.
   `ks` should be a collection of singular keys or vectors of keys
-  pointing at nested data. Vectors are converted into function
-  which (when run on data) will return the data they are poiting at.
+  pointing at nested data. Vectors are interpreted as paths to the relevant data as per `get-in`.
   They also come with a ::descr function in metadata, which describes the
   path using dot notation (e.g.: [:a :b :c] will become 'A.b.c'."
   (map (fn [k]

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -21,11 +21,11 @@
 
 (defn table
   "Creates a table displaying the keys in the given rows of data."
-  ([keys rows {:keys [row->attrs describe-key prepare-keys]
+  ([ks rows {:keys [row->attrs describe-key prepare-keys]
                  :or {row->attrs (constantly {})
                       describe-key describe-key
                       prepare-keys prepare-keys}}]
-   (let [ready-keys (prepare-keys keys)]
+   (let [ready-keys (prepare-keys ks)]
      [:table {:class "table table-hover"}
       [:thead
        (into [:tr]
@@ -36,8 +36,8 @@
               (into [:tr (row->attrs row)]
                     (for [k ready-keys]
                       [:td (k row)]))))]))
-  ([keys rows]
-   (table keys rows {})))
+  ([ks rows]
+   (table ks rows {})))
 
 (defn label
   "Creates a pretty Bootstrap label."

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -1,7 +1,6 @@
 (ns wilson.dom-test
   (:require [wilson.dom :as d]
-            [cljs.test :refer-macros [is are deftest testing]]
-            [wilson.utils :as u]))
+            [cljs.test :refer-macros [is are deftest testing]]))
 
 (deftest panel-test
   (testing "multi-tag header & contents"

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -1,6 +1,6 @@
 (ns wilson.dom-test
   (:require [wilson.dom :as d]
-            [cljs.test :refer-macros [is are deftest testing run-tests]]
+            [cljs.test :refer-macros [is are deftest testing]]
             [wilson.utils :as u]))
 
 (deftest panel-test

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -1,6 +1,7 @@
 (ns wilson.dom-test
   (:require [wilson.dom :as d]
-            [cljs.test :refer-macros [is are deftest testing run-tests]]))
+            [cljs.test :refer-macros [is are deftest testing run-tests]]
+            [wilson.utils :as u]))
 
 (deftest panel-test
   (testing "multi-tag header & contents"
@@ -62,6 +63,39 @@
               [:td "x"]
               [:td "y"]
               [:td (d/label "warning" "z")]]]])))
+  (testing "table with nested data"
+    (is (= (d/table [:a-key :some-key [:a :b :c]]
+                    [{:a-key (d/label "warning" "h")
+                      :some-key "i"
+                      :hidden "hidden"
+                      :a {:b {:c 123}}}
+                     {:a-key "p"
+                      :some-key (d/label "warning" "q")
+                      :hidden "hidden"
+                      :a {:b {:c 456}}}
+                     {:a-key "x"
+                      :some-key "y"
+                      :hidden "hidden"
+                      :a {:b {:c "abc"}}}])
+           [:table {:class "table table-hover"}
+            [:thead
+             [:tr
+              [:th "A key"]
+              [:th "Some key"]
+              [:th "A.b.c"]]]
+            [:tbody
+             [:tr {}
+              [:td (d/label "warning" "h")]
+              [:td "i"]
+              [:td 123]]
+             [:tr {}
+              [:td "p"]
+              [:td (d/label "warning" "q")]
+              [:td 456]]
+             [:tr {}
+              [:td "x"]
+              [:td "y"]
+              [:td "abc"]]]])))
   (testing "table with per-row clases"
     (is (= (d/table [:a-key :some-key :some-other-key]
                     [{:a-key (d/label "warning" "h")


### PR DESCRIPTION
#3 continued:

Improving table to accept `prepare-keys` and `describe-key` methods for more flexibility.
Default implementation of prepare-keys will allow using list of keys as pointer to a data in a nested structure. Default implementation of `describe-key` will display header for the nested data using dot notation (e.g.: `[:a :b :c]` will be represented as "A.b.c").

