### PR TITLE
Sorted table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,156 @@
 
 Wilson is an opinionated library to help you use [Twitter Bootstrap 3][bs3] in [Clojurescript][cljs], particularly with [Reagent][reagent].
 
+
+## Table component
+
+### Simple example
+Display simple table with selected columns:
+
+```clojure
+(:require [wilson.dom :as d])
+
+(d/table
+ (d/prepare-keys [:a [:c :d]])
+ [{:a 1 :b 1 :c {:d "a"}}
+ {:a 3 :b 2 :c {:d "b"}}
+ {:a 8 :b 3 :c {:d "c"}}
+ {:a 2 :b 4 :c {:d "d"}}
+ {:a 4 :b 5 :c {:d "e"}}])
+```
+
+### Sorted rows
+Sort table rows using `wilson.dom/sort-rows` by key `:a`:
+
+```clojure
+(:require [wilson.dom :as d])
+
+(def rows [{:a 1 :b 1 :c {:d "a"}}
+          {:a 3 :b 2 :c {:d "b"}}
+          {:a 8 :b 3 :c {:d "c"}}
+          {:a 2 :b 4 :c {:d "d"}}
+          {:a 4 :b 5 :c {:d "e"}}])
+
+(def sorted-rows (d/sort-rows
+                  rows
+                  {:default (fn [k rows] (sort-by k rows))}
+                  :a))
+
+(d/table
+ (d/prepare-keys [:a [:c :d]])
+ sorted-rows)
+```
+
+### Display all available columns
+Instead of typing columns by hand, you can use `wilson.dom/get-all-keys`:
+
+```clojure
+(:require [wilson.dom :as d])
+
+(def rows [{:a 1 :b 1 :c {:d "a"}}
+          {:a 3 :b 2 :c {:d "b"}}
+          {:a 8 :b 3 :c {:d "c"}}
+          {:a 2 :b 4 :c {:d "d"}}
+          {:a 4 :b 5 :c {:d "e"}}])
+
+(def all-ks (distinct (mapcat d/get-all-keys rows)))
+
+(d/table
+ (d/prepare-keys all-ks)
+ rows)
+```
+
+### Advanced usage
+In this example we will add on-click handlers on table headers to sort the rows
+(and some CSS classes for styling).
+
+```clojure
+(:require [wilson.dom :as d]
+          [reagent.core :as r])
+
+(def ks (prepare-keys [:a :b [:c :d]]))
+
+(defonce state
+  (r/atom {:sort-key (first ks)
+                 :sort-order :asc}))
+
+(defn table-component [state]
+  (let [rows [{:a 1 :b 1 :c {:d "a"}}
+              {:a 3 :b 2 :c {:d "b"}}
+              {:a 8 :b 3 :c {:d "c"}}
+              {:a 2 :b 4 :c {:d "d"}}
+              {:a 4 :b 5 :c {:d "e"}}]
+        sorted-rows (sort-rows
+                     rows
+                     {:default (fn [k rows] (if (= (:sort-order @state) :asc)
+                                              (sort-by k rows)
+                                              (reverse (sort-by k rows))))}
+                     (:sort-key @state))
+        get-new-order (fn [state k]
+                        (let [sort-key (:sort-key @state)
+                              sort-order (:sort-order @state)
+                              swap-order {:asc :desc :desc :asc}]
+                          {:sort-key k
+                           :sort-order (if (= sort-key k)
+                                           (swap-order sort-order)
+                                           :asc)}))
+        update-state-order #(swap! state merge (get-new-order state %))]
+   (with-class "sorted-table"
+    (table
+     ks
+     sorted-rows
+     {:k->attrs (fn [k]
+                 {:on-click #(update-state-order k)
+                  :class (when (= k (:sort-key @state))
+                          (name (:sort-order @state)))})}))))
+```
+
+Add some CSS to provide visual cues to the user:
+
+```css
+.sorted-table > thead > tr > th {
+  position: relative;
+  cursor: pointer;
+  padding-left: 20px;
+}
+
+.sorted-table th:before {
+  content: "";
+  border-right: 3px solid transparent;
+  border-bottom: 3px solid #b6b6b6;
+  border-left: 3px solid transparent;
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-top: -2px;
+}
+
+.sorted-table th:after {
+  content: "";
+  border-right: 3px solid transparent;
+  border-top: 3px solid #b6b6b6;
+  border-left: 3px solid transparent;
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-top: 3px;
+}
+
+.sorted-table .asc:before {
+  border-bottom-color: #111;
+}
+
+.sorted-table .desc:after {
+  border-top-color: #111;
+}
+```
+
+Now when you render `table-component` you'll get a table with live sorting on the front-end.
+
+
+
 [book]: https://en.wikipedia.org/wiki/By_His_Bootstraps
 [bs3]: http://getbootstrap.com/
 [cljs]: https://github.com/clojure/clojurescript

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -50,10 +50,10 @@
   "Creates a table displaying the keys in the given rows of data.
   Accepts singular keys or vectors of keys pointing at nested data."
   ([ks rows {:keys [row->attrs k->attrs describe-key prepare-keys]
-                 :or {row->attrs (constantly {})
-                      k->attrs (constantly {})
-                      describe-key describe-key
-                      prepare-keys prepare-keys}}]
+               :or {row->attrs (constantly {})
+                    k->attrs (constantly {})
+                    describe-key describe-key
+                    prepare-keys prepare-keys}}]
    (let [ready-keys (prepare-keys ks)]
      [:table {:class "table"}
       [:thead

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -4,8 +4,8 @@
             [clojure.string :as string]))
 
 (defn describe-key
-  [k]
   "Returns a key in a human-readable form."
+  [k]
   (if (keyword? k)
       (capitalize k)
       (::descr (meta k))))

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -27,6 +27,8 @@
        ks))
 
 (defn get-all-keys
+  "Returns a list of all available keys in a map. Nested branches will
+  be represented as paths to the relevant data (as per `get-in`)."
   [m]
   (when (map? m)
    (mapcat (fn [[k v]]
@@ -37,6 +39,8 @@
            m)))
 
 (defn sort-rows
+  "Sorts rows `by-key` using corresponding sorting function.
+  If `by-key` is not found in `sort-fns` map then `:default` will be used."
   [rows sort-fns by-key]
   (if (contains? sort-fns by-key)
       ((by-key sort-fns) by-key rows)

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -26,6 +26,12 @@
            k))
        ks))
 
+(defn sort-rows
+  [rows sort-fns by-key]
+  (if (contains? sort-fns by-key)
+      ((by-key sort-fns) by-key rows)
+      ((:default sort-fns) by-key rows)))
+
 (defn table
   "Creates a table displaying the keys in the given rows of data.
   Accepts singular keys or vectors of keys pointing at nested data."

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -54,7 +54,7 @@
                       describe-key describe-key
                       prepare-keys prepare-keys}}]
    (let [ready-keys (prepare-keys ks)]
-     [:table {:class "table table-hover"}
+     [:table {:class "table"}
       [:thead
        (into [:tr]
              (for [k ready-keys]

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -52,20 +52,18 @@
   ([ks rows {:keys [row->attrs k->attrs describe-key prepare-keys]
                :or {row->attrs (constantly {})
                     k->attrs (constantly {})
-                    describe-key describe-key
-                    prepare-keys prepare-keys}}]
-   (let [ready-keys (prepare-keys ks)]
-     [:table {:class "table"}
-      [:thead
-       (into [:tr]
-             (for [k ready-keys]
-               [:th (k->attrs k)
-                (describe-key k)]))]
-      (into [:tbody]
-            (for [row rows]
-              (into [:tr (row->attrs row)]
-                    (for [k ready-keys]
-                      [:td (k row)]))))]))
+                    describe-key describe-key}}]
+   [:table {:class "table"}
+    [:thead
+     (into [:tr]
+           (for [k ks]
+             [:th (k->attrs k)
+              (describe-key k)]))]
+    (into [:tbody]
+          (for [row rows]
+            (into [:tr (row->attrs row)]
+                  (for [k ks]
+                    [:td (k row)]))))])
   ([ks rows]
    (table ks rows {})))
 

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -26,6 +26,16 @@
            k))
        ks))
 
+(defn get-all-keys
+  [m]
+  (when (map? m)
+   (mapcat (fn [[k v]]
+            (let [nested (->> (get-all-keys v)
+                              (filter seq)
+                              (map (partial into [k])))]
+              (if (seq nested) nested [[k]])))
+           m)))
+
 (defn sort-rows
   [rows sort-fns by-key]
   (if (contains? sort-fns by-key)

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -49,8 +49,9 @@
 (defn table
   "Creates a table displaying the keys in the given rows of data.
   Accepts singular keys or vectors of keys pointing at nested data."
-  ([ks rows {:keys [row->attrs describe-key prepare-keys]
+  ([ks rows {:keys [row->attrs k->attrs describe-key prepare-keys]
                  :or {row->attrs (constantly {})
+                      k->attrs (constantly {})
                       describe-key describe-key
                       prepare-keys prepare-keys}}]
    (let [ready-keys (prepare-keys ks)]
@@ -58,7 +59,8 @@
       [:thead
        (into [:tr]
              (for [k ready-keys]
-               [:th (describe-key k)]))]
+               [:th (k->attrs k)
+                (describe-key k)]))]
       (into [:tbody]
             (for [row rows]
               (into [:tr (row->attrs row)]

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -28,6 +28,13 @@
     (is (= (d/label "warning" "Alert!")
            [:span {:class "label label-warning"} "Alert!"]))))
 
+(deftest get-all-keys-test
+  (testing "getting all keys from nested map"
+    (is (= (d/get-all-keys {:a {:b "abc"}
+                            :c 123
+                            :d {:e {:f "abc"}}})
+           [[:a :b] [:c] [:d :e :f]]))))
+
 (deftest sort-rows-test
   (let [rows [{:a 1 :b "B" :c {:x "abc"}}
               {:a 4 :b "A" :c :y}

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -70,7 +70,7 @@
                       :some-key "y"
                       :some-other-key (d/label "warning" "z")
                       :hidden "hidden"}])
-           [:table {:class "table table-hover"}
+           [:table {:class "table"}
             [:thead
              [:tr
               [:th "A key"]
@@ -103,7 +103,7 @@
                       :some-key "y"
                       :hidden "hidden"
                       :a {:b {:c "abc"}}}])
-           [:table {:class "table table-hover"}
+           [:table {:class "table"}
             [:thead
              [:tr
               [:th "A key"]
@@ -141,7 +141,7 @@
                                    "j" {:class "warning"}
                                    "r" {:class "success"}
                                    {:class "info"}))})
-           [:table {:class "table table-hover"}
+           [:table {:class "table"}
             [:thead
              [:tr
               [:th "A key"]

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -28,6 +28,26 @@
     (is (= (d/label "warning" "Alert!")
            [:span {:class "label label-warning"} "Alert!"]))))
 
+(deftest sort-rows-test
+  (let [rows [{:a 1 :b "B" :c {:x "abc"}}
+              {:a 4 :b "A" :c :y}
+              {:a 3 :b "D" :c {:a "def"}}
+              {:a 2 :b "C" :c :z}]
+        sort-fns {:default (fn [k rows] (sort-by k rows))
+                  :b (fn [k rows] (reverse (sort-by k rows)))}]
+    (testing "default order fuction"
+     (is (= (d/sort-rows rows sort-fns :a)
+            [{:a 1 :b "B" :c {:x "abc"}}
+             {:a 2 :b "C" :c :z}
+             {:a 3 :b "D" :c {:a "def"}}
+             {:a 4 :b "A" :c :y}])))
+    (testing "per-key order fuction"
+     (is (= (d/sort-rows rows sort-fns :b)
+            [{:a 3 :b "D" :c {:a "def"}}
+             {:a 2 :b "C" :c :z}
+             {:a 1 :b "B" :c {:x "abc"}}
+             {:a 4 :b "A" :c :y}])))))
+
 (deftest table-test
   (testing "simple table"
     (is (= (d/table [:a-key :some-key :some-other-key]

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -73,9 +73,9 @@
            [:table {:class "table"}
             [:thead
              [:tr
-              [:th "A key"]
-              [:th "Some key"]
-              [:th "Some other key"]]]
+              [:th {} "A key"]
+              [:th {} "Some key"]
+              [:th {} "Some other key"]]]
             [:tbody
              [:tr {}
               [:td (d/label "warning" "h")]
@@ -106,9 +106,9 @@
            [:table {:class "table"}
             [:thead
              [:tr
-              [:th "A key"]
-              [:th "Some key"]
-              [:th "A.b.c"]]]
+              [:th {} "A key"]
+              [:th {} "Some key"]
+              [:th {} "A.b.c"]]]
             [:tbody
              [:tr {}
               [:td (d/label "warning" "h")]
@@ -144,9 +144,9 @@
            [:table {:class "table"}
             [:thead
              [:tr
-              [:th "A key"]
-              [:th "Some key"]
-              [:th "Some other key"]]]
+              [:th {} "A key"]
+              [:th {} "Some key"]
+              [:th {} "Some other key"]]]
             [:tbody
              [:tr {:class "warning"}
               [:td (d/label "warning" "h")]

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -57,7 +57,7 @@
 
 (deftest table-test
   (testing "simple table"
-    (is (= (d/table [:a-key :some-key :some-other-key]
+    (is (= (d/table (d/prepare-keys [:a-key :some-key :some-other-key])
                     [{:a-key (d/label "warning" "h")
                       :some-key "i"
                       :some-other-key "j"
@@ -90,7 +90,7 @@
               [:td "y"]
               [:td (d/label "warning" "z")]]]])))
   (testing "table with nested data"
-    (is (= (d/table [:a-key :some-key [:a :b :c]]
+    (is (= (d/table (d/prepare-keys [:a-key :some-key [:a :b :c]])
                     [{:a-key (d/label "warning" "h")
                       :some-key "i"
                       :hidden "hidden"
@@ -123,7 +123,7 @@
               [:td "y"]
               [:td "abc"]]]])))
   (testing "table with per-row clases"
-    (is (= (d/table [:a-key :some-key :some-other-key]
+    (is (= (d/table (d/prepare-keys [:a-key :some-key :some-other-key])
                     [{:a-key (d/label "warning" "h")
                       :some-key "i"
                       :some-other-key "j"


### PR DESCRIPTION
Adds `get-all-keys` and `sort-rows`. Those will be used to implement sorting and cols-toggler on the table. Should we add example use of those fns with table to the readme?

Also, most common use case would be to add an `on-click` handler to a table's headers to implement sorting. There are some visual changes involved then that should indicate to the user what's happening (by which column sorting currently happens, is it ascending or descending?). I wonder if we should styles for that inside Wilson?