### PR TITLE
with-class should work with form-2 components

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                         ["snapshots" :clojars]]
 
   :dependencies [[org.clojure/clojurescript "1.8.51" :scope "provided"]
-                 [reagent "0.5.1"]
+                 [reagent "0.6.0-alpha"]
                  [hiccup "1.0.5"]
                  [secretary "1.2.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
@@ -42,7 +42,7 @@
                                          :pretty-print true}}}}
 
   :figwheel {:http-server-root "public"
-             :server-port 3449
+             :server-port 3001
              :css-dirs ["resources/public/css"]
              :ring-handler wilson.handler/app}
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                         ["snapshots" :clojars]]
 
   :dependencies [[org.clojure/clojurescript "1.8.51" :scope "provided"]
-                 [reagent "0.6.0-alpha"]
+                 [reagent "0.5.1"]
                  [hiccup "1.0.5"]
                  [secretary "1.2.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
@@ -42,7 +42,7 @@
                                          :pretty-print true}}}}
 
   :figwheel {:http-server-root "public"
-             :server-port 3001
+             :server-port 3449
              :css-dirs ["resources/public/css"]
              :ring-handler wilson.handler/app}
 

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -174,9 +174,15 @@
   (update elem 1 merge-attrs attrs))
 
 (defn with-class
-  "Adds a class to an element."
-  [cls elem]
-  (with-attrs {:class cls} elem))
+  "Adds a class to a component."
+  [cls component]
+  (if (vector? component)
+   (r/as-element (with-attrs {:class cls} component))
+   (fn with-class-outer* [_ _ & outer-props]
+    (let [outer-comp (apply component outer-props)]
+      (fn with-class-inner* [_ _ & inner-props]
+        (let [inner-comp (apply outer-comp inner-props)]
+          (with-attrs {:class cls} inner-comp)))))))
 
 (defn icon
   "Creates a Glyphicon.

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -2,8 +2,7 @@
   "Tools for building DOMs."
   (:require [wilson.utils :refer [capitalize]]
             [clojure.string :as string]
-            [reagent.core :as r]
-            [cljs.core.match :refer-macros [match]]))
+            [reagent.core :as r]))
 
 (defn describe-key
   "Returns a key in a human-readable form."
@@ -181,11 +180,8 @@
                     (let [outer-comp (apply render-fn outer-props)]
                       (fn [_ & inner-props]
                         (let [inner-comp (apply outer-comp inner-props)]
-                          (with-attrs {:class cls} inner-comp)))))
-        [render-fn] (match component
-                      [render-fn & _]
-                      [render-fn])]
-    (if (keyword? render-fn)
+                          (with-attrs {:class cls} inner-comp)))))]
+    (if (keyword? (first component))
       (with-attrs {:class cls} component)
       (into [parse-f2c] component))))
 

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -178,13 +178,13 @@
   "Adds a class to a component."
   [cls component]
   (let [parse-f2c (fn [render-fn & outer-props]
-                   (let [outer-comp (apply render-fn outer-props)]
-                    (fn [_ & inner-props]
-                     (let [inner-comp (apply outer-comp inner-props)]
-                      (with-attrs {:class cls} inner-comp)))))
+                    (let [outer-comp (apply render-fn outer-props)]
+                      (fn [_ & inner-props]
+                        (let [inner-comp (apply outer-comp inner-props)]
+                          (with-attrs {:class cls} inner-comp)))))
         [render-fn] (match component
-                           [render-fn & _]
-                           [render-fn])]
+                      [render-fn & _]
+                      [render-fn])]
     (if (keyword? render-fn)
       (with-attrs {:class cls} component)
       (into [parse-f2c] component))))

--- a/test/wilson/core_test.cljs
+++ b/test/wilson/core_test.cljs
@@ -8,6 +8,8 @@
 
 (def rflush reagent/flush)
 
+(defn rstr [el] (reagent/render-to-static-markup el))
+
 (defn add-test-div [name]
   (let [doc     js/document
         body    (.-body js/document)

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -3,7 +3,7 @@
             [cljs.test :refer-macros [is are deftest testing]]
             [cljs.core.match :refer-macros [match]]
             [reagent.core :as r]
-            [wilson.core-test :refer [rflush with-mounted-component]]))
+            [wilson.core-test :refer [rflush with-mounted-component rstr]]))
 
 (defn click-dom-el
   "Dispatch click mouse-event (Web API) on given element."
@@ -295,17 +295,32 @@
   (testing "merge with existing classes"
     (is (= (d/with-class "panel" [:a {:class "colorful" :href "/xyzzy"}])
            [:a {:href "/xyzzy" :class "colorful panel"}])))
-  (let [state (r/atom {})
-        rows [{:a 1 :b "B" :c -6}
-              {:a 4 :b "A" :c 2}
-              {:a 3 :b "D" :c 4}]
-        ks (d/prepare-keys [:a :b :c])]
-    (with-mounted-component (d/with-class "some-class" [d/sorted-table ks rows state])
-      (fn [c div]
-        (let [table-el (.querySelector div "table")
-              has-class? (fn [cls el] (.contains (.-classList el) cls))]
-          (testing "with-class on form-2 component"
-            (is (has-class? "some-class" table-el))))))))
+  (testing "with-class on form-2 component"
+    (let [state (r/atom {})
+          rows [{:a 1 :b "B" :c -6}
+                {:a 4 :b "A" :c 2}
+                {:a 3 :b "D" :c 4}]
+          ks (d/prepare-keys [:a :b :c])]
+      (is (= (rstr (d/with-class "some-class" [d/sorted-table ks rows state]))
+             (rstr [:table {:class "table some-class"}
+                    [:thead
+                     [:tr
+                      [:th "A"]
+                      [:th "B"]
+                      [:th "C"]]]
+                    [:tbody
+                     [:tr
+                      [:td "1"]
+                      [:td "B"]
+                      [:td "-6"]]
+                     [:tr
+                      [:td "4"]
+                      [:td "A"]
+                      [:td "2"]]
+                     [:tr
+                      [:td "3"]
+                      [:td "D"]
+                      [:td "4"]]]]))))))
 
 (deftest icon-test
   (is (= (d/icon "download")

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -268,7 +268,17 @@
            [:a {:href "/xyzzy" :class "panel"}])))
   (testing "merge with existing classes"
     (is (= (d/with-class "panel" [:a {:class "colorful" :href "/xyzzy"}])
-           [:a {:href "/xyzzy" :class "colorful panel"}]))))
+           [:a {:href "/xyzzy" :class "colorful panel"}])))
+  (let [state (r/atom {})
+        rows [{:a 1 :b "B" :c -6}
+              {:a 4 :b "A" :c 2}
+              {:a 3 :b "D" :c 4}]
+        ks (d/prepare-keys [:a :b :c])]
+    (with-mounted-component (d/with-class "some-class" [d/sorted-table ks rows state])
+     (fn [c div]
+       (let [table-el (.querySelector div "table")
+             has-class? (fn [cls el] (.contains (.-classList el) cls))]
+         (is (has-class? "some-class" table-el)))))))
 
 (deftest icon-test
   (is (= (d/icon "download")

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -278,7 +278,8 @@
      (fn [c div]
        (let [table-el (.querySelector div "table")
              has-class? (fn [cls el] (.contains (.-classList el) cls))]
-         (is (has-class? "some-class" table-el)))))))
+         (testing "with-class on form-2 component"
+           (is (has-class? "some-class" table-el))))))))
 
 (deftest icon-test
   (is (= (d/icon "download")

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -275,11 +275,11 @@
               {:a 3 :b "D" :c 4}]
         ks (d/prepare-keys [:a :b :c])]
     (with-mounted-component (d/with-class "some-class" [d/sorted-table ks rows state])
-     (fn [c div]
-       (let [table-el (.querySelector div "table")
-             has-class? (fn [cls el] (.contains (.-classList el) cls))]
-         (testing "with-class on form-2 component"
-           (is (has-class? "some-class" table-el))))))))
+      (fn [c div]
+        (let [table-el (.querySelector div "table")
+              has-class? (fn [cls el] (.contains (.-classList el) cls))]
+          (testing "with-class on form-2 component"
+            (is (has-class? "some-class" table-el))))))))
 
 (deftest icon-test
   (is (= (d/icon "download")


### PR DESCRIPTION
with this implementation, calling `[with-class sorted-table ks rows state]` will correctly render the component. It will also work with standard hiccups, tho the returned value is no longer as simple, so this won't evaluate to true:

```clojure
(is (= (with-class "some-class" [:a])
       [:a {:class "some-class"}]))
```
I think that `with-class` is not the best idea in the first place - components we create should accept attributes by default, without need for additional fn. 
But since it's here and we find use for it, `with-class` should work in a way that:

- works with hiccups and doesn't complicate the output
- works with form-2 components and properly renders them usin `[]`, so they are reactive