### PR TITLE
Merge k->attr attrs for sorted-table

### DIFF
--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -4,6 +4,8 @@
             [clojure.string :as string]
             [reagent.core :as r]))
 
+(declare merge-attrs)
+
 (defn describe-key
   "Returns a key in a human-readable form."
   [k]
@@ -114,14 +116,16 @@
                                          (swap-order (sort-order-id state))
                                          :asc)})))
              update-state-order #(swap! state get-new-order %)
-             default-opts {:k->attrs
-                           (fn [k]
-                             (let [state-deref @state]
-                               {:class
-                                (when (= k (sort-key-id state-deref))
-                                  (name (sort-order-id state-deref)))
-                                :on-click #(update-state-order k)}))}]
-         (table ks maybe-sorted-rows (merge default-opts opts))))))
+             update-opts (update opts :k->attrs
+                                 (fn [user-k->attrs]
+                                   (fn [k]
+                                     (let [u (when user-k->attrs (user-k->attrs k))
+                                           sort-class (when (= k (sort-key-id state-deref))
+                                                        (name (sort-order-id state-deref)))]
+                                       (merge-attrs {:class sort-class
+                                                     :on-click #(update-state-order k)}
+                                                    u)))))]
+         (table ks maybe-sorted-rows update-opts)))))
   ([ks rows state]
    (sorted-table ks rows state {})))
 

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -244,7 +244,19 @@
             (is (= (.-className first-th) "asc")))
           (click)
           (testing "clicking second time changes sorting order"
-            (is (= (.-className first-th) "desc"))))))))
+            (is (= (.-className first-th) "desc"))))))
+
+    (with-mounted-component [d/sorted-table ks rows state {:k->attrs
+                                                           (fn [k]
+                                                             {:class "some-class"})}]
+      (fn [c div]
+        (let [first-th (.querySelector div "th:first-of-type")
+              click #(do (click-dom-el first-th) (rflush))]
+          (testing "first th should have class added"
+            (is (= (.-className first-th) "some-class")))
+          (click)
+          (testing "on-click should still work"
+            (is (= (.-className first-th) "asc some-class"))))))))
 
 (deftest button-test
   (let [t "Some text"


### PR DESCRIPTION
Previously, passing k->attrs to sorted-table would override current classes/on-click and hence disable the whole functionality. Now stuff gets properly merged 