### PR TITLE
Fix modals

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wilson "0.31.0-SNAPSHOT"
+(defproject wilson "0.32.0-SNAPSHOT"
   :description "Opinionated Reagent bindings for Bootstrap components."
   :url "https://www.github.com/racksec/wilson"
   :license {:name "Eclipse Public License"

--- a/src/wilson/dom.cljs
+++ b/src/wilson/dom.cljs
@@ -253,8 +253,8 @@
   ([title content btn-text state]
    (modal-button title content btn-text state {}))
   ([title content btn-text state attrs]
-   (swap! state merge {:wilson-modal {:title title :content content}})
-   (fn [title content btn-text state attrs]
-     [:a (merge {:on-click #(swap! state assoc-in [:wilson-modal :show?] true)}
-                attrs)
-      btn-text])))
+   [:a (merge {:on-click #(swap! state assoc :wilson-modal {:show? true
+                                                            :title title
+                                                            :content content})}
+              attrs)
+    btn-text]))

--- a/test/wilson/dom_test.cljs
+++ b/test/wilson/dom_test.cljs
@@ -362,9 +362,11 @@
       (fn [c div]
         (let [button (.querySelector div "#toggle")
               modal-state (:wilson-modal @state)]
-          (is (= (:title modal-state) "Modal title"))
-          (is (= (:content modal-state) "Modal content"))
+          (is (nil? (:title modal-state)))
+          (is (nil? (:content modal-state)))
           (is (nil? (:show modal-state)))
           (click-dom-el button)
           (is (true? (get-in @state [:wilson-modal :show?])))
+          (is (= (get-in @state [:wilson-modal :title]) "Modal title"))
+          (is (= (get-in @state [:wilson-modal :content]) "Modal content"))
           (is (= (.-text button) "Click me!")))))))


### PR DESCRIPTION
We set modal content for each modal-button instance when button is rendered (and only then). Content should be set on each modal trigger (otherwise content doesn't change at all)